### PR TITLE
add support email validation rule

### DIFF
--- a/DEVELOPER_DOC.md
+++ b/DEVELOPER_DOC.md
@@ -45,6 +45,9 @@ Sample cookbook JSON
 }
 ```
 
+### Support email validation rule 
+We accept emails that fit `^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z0-9]{2,})$` regular expression.
+
 ## Item
 
 Item consists of below fields.


### PR DESCRIPTION
Close #10 

We support `^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z0-9]{2,})$` which accept "junkai@quiver.network"