### PR TITLE
update logging to level 2

### DIFF
--- a/cmd/fixtures_test/step_runner.go
+++ b/cmd/fixtures_test/step_runner.go
@@ -60,7 +60,7 @@ func RunMultiMsgTx(step FixtureStep, t *testing.T) {
 			"len_msgs": len(msgs),
 			"tx_msgs":  inttest.AminoCodecFormatter(msgs),
 			"msg_refs": step.MsgRefs,
-		}).Debug("debug log")
+		}).AddFields(inttest.GetLogFieldsFromMsgs(msgs)).Debug("debug log")
 		txhash, err := inttest.SendMultiMsgTxWithNonce(t, msgs, sender.String(), true)
 		t.MustNil(err)
 
@@ -536,8 +536,8 @@ func RunCreateTrade(step FixtureStep, t *testing.T) {
 	if step.ParamsRef != "" {
 		createTrd := CreateTradeMsgFromRef(step.ParamsRef, t)
 		t.WithFields(testing.Fields{
-			"tx_msg": inttest.AminoCodecFormatter(createTrd),
-		}).Debug("createTrd")
+			"tx_msgs": inttest.AminoCodecFormatter(createTrd),
+		}).AddFields(inttest.GetLogFieldsFromMsgs([]sdk.Msg{createTrd})).Debug("createTrd")
 		txhash := inttest.TestTxWithMsgWithNonce(t, createTrd, createTrd.Sender.String(), true)
 		err := inttest.WaitForNextBlock()
 		if err != nil {

--- a/cmd/test/tx_utils.go
+++ b/cmd/test/tx_utils.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	testing "github.com/Pylons-tech/pylons_sdk/cmd/fixtures_test/evtesting"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
@@ -189,11 +190,16 @@ func TestTxWithMsg(t *testing.T, msgValue sdk.Msg, signer string) string {
 // SendMultiMsgTxWithNonce is a function to send multiple messages in one transaction
 func SendMultiMsgTxWithNonce(t *testing.T, msgs []sdk.Msg, signer string, isBech32Addr bool) (string, error) {
 	t.WithFields(testing.Fields{
-		"func_start":     "SendMultiMsgTxWithNonce",
-		"tx_msgs":        AminoCodecFormatter(msgs),
-		"signer":         signer,
-		"is_bech32_addr": isBech32Addr,
-	}).Debug("debug log")
+		"action":    "func_start",
+		"signer":    signer,
+		"is_bech32": isBech32Addr,
+	}).
+		AddFields(GetLogFieldsFromMsgs(msgs)).
+		AddFields(log.Fields{
+			"tx_msgs": AminoCodecFormatter(msgs),
+		}).
+		SetFieldsOrder(testing.SortCustomKey, []string{"action", "signer", "is_bech32"}).
+		Debug("debug log")
 
 	if len(msgs) == 0 {
 		return "msgs validation error", errors.New("length of msgs shouldn't be zero")
@@ -294,11 +300,17 @@ func SendMultiMsgTxWithNonce(t *testing.T, msgs []sdk.Msg, signer string, isBech
 	CleanFile(signedTxFile, t)
 
 	t.WithFields(testing.Fields{
-		"func_end":       "SendMultiMsgTxWithNonce",
-		"tx_msgs":        AminoCodecFormatter(msgs),
-		"signer":         signer,
-		"is_bech32_addr": isBech32Addr,
-	}).Debug("debug log")
+		"action":    "func_end",
+		"txhash":    txhash,
+		"signer":    signer,
+		"is_bech32": isBech32Addr,
+	}).
+		AddFields(GetLogFieldsFromMsgs(msgs)).
+		AddFields(log.Fields{
+			"tx_msgs": AminoCodecFormatter(msgs),
+		}).
+		SetFieldsOrder(testing.SortCustomKey, []string{"action", "txhash", "signer", "is_bech32"}).
+		Debug("debug log")
 	return txhash, nil
 }
 


### PR DESCRIPTION
- Added GetLogFieldsFromMsgs, AddFields to collect top level data like recipe_id on top level
- Added SetFieldsOrder function to control log key output orders and add 4 sort types that might be useful  NoSort, SortKeyAlphaBet, SortCustomKey, SortValueLength
- Added a possibility to have custom log level by using NewLogLevelT