### PR TITLE
hotfix for accountNames undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ var runSerialMode = false
 var useRest = false
 var useKnownCookbook = false
 var scenarios = ""
+var accounts = ""
 
 func init() {
 	flag.BoolVar(&runSerialMode, "runserial", false, "true/false value to check if test will be running in parallel")
 	flag.BoolVar(&useRest, "userest", false, "use rest endpoint for Tx send")
 	flag.BoolVar(&useKnownCookbook, "use-known-cookbook", false, "use existing cookbook or not")
 	flag.StringVar(&scenarios, "scenarios", "", "custom scenario file names")
+	flag.StringVar(&accounts, "accounts", "", "custom account names")
 }
 
 func TestFixturesViaCLI(t *testing.T) {
@@ -63,6 +65,10 @@ func TestFixturesViaCLI(t *testing.T) {
 	scenarioFileNames := []string{}
 	if len(scenarios) > 0 {
 		scenarioFileNames = strings.Split(scenarios, ",")
+	}
+	fixturetestSDK.FixtureTestOpts.AccountNames = []string{}
+	if len(accounts) > 0 {
+		FixtureTestOpts.AccountNames = strings.Split(accounts, ",")
 	}
 	fixturetestSDK.RunTestScenarios("scenarios", scenarioFileNames, t)
 }

--- a/cmd/fixtures_test/README.md
+++ b/cmd/fixtures_test/README.md
@@ -108,7 +108,7 @@ make fixture_tests ARGS="--scenarios=multi_msg_tx,double_empty"
 - set account names to be used for the fixture tests.
 The account names will replace all the placeholder account names in the fixture test files.
 ```
-make fixture_tests ARGS="--accounts michael,eugen"
+make fixture_tests ARGS="--accounts=michael,eugen"
 ```
 
 ## To make fixture test scenarios clean

--- a/cmd/fixtures_test/check_utils.go
+++ b/cmd/fixtures_test/check_utils.go
@@ -62,6 +62,7 @@ type FixtureStep struct {
 type TestOptions struct {
 	IsParallel        bool
 	CreateNewCookbook bool
+	AccountNames      []string
 }
 
 // FixtureTestOpts is a variable to have fixture test options

--- a/cmd/fixtures_test/fixture_test.go
+++ b/cmd/fixtures_test/fixture_test.go
@@ -13,7 +13,6 @@ var useRest = false
 var useKnownCookbook = false
 var scenarios = ""
 var accounts = ""
-var accountNames []string
 
 func init() {
 	flag.BoolVar(&runSerialMode, "runserial", false, "true/false value to check if test will be running in parallel")
@@ -35,12 +34,12 @@ func TestFixturesViaCLI(t *testing.T) {
 	// Register custom action runners
 	// RegisterActionRunner("custom_action", CustomActionRunner)
 	scenarioFileNames := []string{}
-	accountNames = []string{}
 	if len(scenarios) > 0 {
 		scenarioFileNames = strings.Split(scenarios, ",")
 	}
+	FixtureTestOpts.AccountNames = []string{}
 	if len(accounts) > 0 {
-		accountNames = strings.Split(accounts, ",")
+		FixtureTestOpts.AccountNames = strings.Split(accounts, ",")
 	}
 	RunTestScenarios("scenarios", scenarioFileNames, t)
 }

--- a/cmd/fixtures_test/struct_utils.go
+++ b/cmd/fixtures_test/struct_utils.go
@@ -66,9 +66,9 @@ func GetAccountAddressFromTempName(tempName string, t *testing.T) string {
 	// temp names start from account1, so it's subtracted to match to the index
 	accountNameIndex--
 
-	t.MustTrue(accountNameIndex < len(accountNames), fmt.Sprintf("%s doesn't match to the accounts args. the account index is out of the account args length", tempName))
+	t.MustTrue(accountNameIndex < len(FixtureTestOpts.AccountNames), fmt.Sprintf("%s doesn't match to the accounts args. the account index is out of the account args length", tempName))
 
-	return inttest.GetAccountAddr(accountNames[accountNameIndex], t)
+	return inttest.GetAccountAddr(FixtureTestOpts.AccountNames[accountNameIndex], t)
 }
 
 // UpdateSenderKeyToAddress is a function to update sender key to sender's address


### PR DESCRIPTION
This fixes accountNames undefined on pylons repo.

```
../../../go/pkg/mod/github.com/!pylons-tech/pylons_sdk@v0.0.0-20200623140813-e931fc3bf647/cmd/fixtures_test/struct_utils.go:69:36: undefined: accountNames
../../../go/pkg/mod/github.com/!pylons-tech/pylons_sdk@v0.0.0-20200623140813-e931fc3bf647/cmd/fixtures_test/struct_utils.go:71:32: undefined: accountNames
```