### PR TITLE
log full trace stack for unmarshal issues

### DIFF
--- a/cmd/fixtures_test/check_utils.go
+++ b/cmd/fixtures_test/check_utils.go
@@ -342,7 +342,7 @@ func RunSingleFixtureTest(file string, t *testing.T) {
 		err := json.Unmarshal([]byte(byteValue), &fixtureSteps)
 		t.WithFields(testing.Fields{
 			"raw_json": string(byteValue),
-		}).MustNil(err, "something went wrong decoding fixture steps")
+		}).MustNil(err, "error decoding fixture steps")
 
 		CheckSteps(fixtureSteps, t)
 

--- a/cmd/fixtures_test/evtesting/evtesting.go
+++ b/cmd/fixtures_test/evtesting/evtesting.go
@@ -283,10 +283,6 @@ func (t *T) MustTrue(value bool, args ...interface{}) {
 				"error_from": "MustTrue validation failure",
 			}).Fatal(args...)
 	}
-
-	// if !t.useLogPkg {
-	// 	require.True(t.origin, value)
-	// }
 }
 
 // MustNil validate if error is nil
@@ -300,9 +296,6 @@ func (t *T) MustNil(err error, args ...interface{}) {
 				"error_from": "MustNil validation failure",
 			}).Fatal(args...)
 	}
-	// if !t.useLogPkg {
-	// 	require.True(t.origin, err == nil)
-	// }
 }
 
 // MustContain check srcstring contains substring
@@ -318,10 +311,6 @@ func (t *T) MustContain(srcstring, substring string, args ...interface{}) {
 				"error_from": "MustContain validation failure",
 			}).Fatal(args...)
 	}
-
-	// if !t.useLogPkg {
-	// 	require.True(t.origin, value)
-	// }
 }
 
 // Parallel is modified Parallel

--- a/cmd/fixtures_test/evtesting/evtesting.go
+++ b/cmd/fixtures_test/evtesting/evtesting.go
@@ -307,10 +307,21 @@ func (t *T) MustNil(err error, args ...interface{}) {
 
 // MustContain check srcstring contains substring
 func (t *T) MustContain(srcstring, substring string, args ...interface{}) {
-	t.WithFields(Fields{
-		"src_string": srcstring,
-		"sub_string": substring,
-	}).MustTrue(strings.Contains(srcstring, substring), args...)
+	value := strings.Contains(srcstring, substring)
+	if !value {
+		t.DispatchEvent("FAIL")
+		t.printEntireStack()
+		t.WithFields(Fields(t.fields)).
+			AddFields(log.Fields{
+				"src_string": srcstring,
+				"sub_string": substring,
+				"error_from": "MustContain validation failure",
+			}).Fatal(args...)
+	}
+
+	// if !t.useLogPkg {
+	// 	require.True(t.origin, value)
+	// }
 }
 
 // Parallel is modified Parallel

--- a/cmd/fixtures_test/struct_utils.go
+++ b/cmd/fixtures_test/struct_utils.go
@@ -36,11 +36,10 @@ func ReadFile(fileURL string, t *testing.T) []byte {
 // UnmarshalIntoEmptyInterface is a function to convert bytes into map[string]interface{}
 func UnmarshalIntoEmptyInterface(bytes []byte, t *testing.T) map[string]interface{} {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(bytes, &raw); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &raw)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling")
 	return raw
 }
 
@@ -60,7 +59,7 @@ func GetAccountAddressFromTempName(tempName string, t *testing.T) string {
 	err := ValidateTempAccountName(tempName)
 	t.MustNil(err, fmt.Sprintf("%s is an invalid account name", tempName))
 
-	accountNameIndex, err := strconv.Atoi(strings.TrimLeft(tempName, "account"))
+	accountNameIndex, err := strconv.Atoi(strings.TrimPrefix(tempName, "account"))
 	t.MustNil(err, fmt.Sprintf("%s is an invalid account name", tempName))
 	t.MustTrue(accountNameIndex > 0, fmt.Sprintf("%s doesn't match to the accounts args. temp account names start from account1", tempName))
 	// temp names start from account1, so it's subtracted to match to the index
@@ -82,7 +81,7 @@ func UpdateSenderKeyToAddress(bytes []byte, t *testing.T) []byte {
 	newBytes, err := json.Marshal(raw)
 	t.WithFields(testing.Fields{
 		"updated_sender_interface": raw,
-	}).MustNil(err, "something went wrong encoding raw json")
+	}).MustNil(err, "error encoding raw json")
 	return newBytes
 }
 
@@ -96,7 +95,7 @@ func UpdateReceiverKeyToAddress(bytes []byte, t *testing.T) []byte {
 	newBytes, err := json.Marshal(raw)
 	t.WithFields(testing.Fields{
 		"updated_receiver_interface": raw,
-	}).MustNil(err, "something went wrong encoding raw json")
+	}).MustNil(err, "error encoding raw json")
 	return newBytes
 }
 
@@ -114,7 +113,7 @@ func UpdateCBNameToID(bytes []byte, t *testing.T) []byte {
 		newBytes, err := json.Marshal(raw)
 		t.WithFields(testing.Fields{
 			"updated_cookbook_id_interface": raw,
-		}).MustNil(err, "something went wrong encoding raw json")
+		}).MustNil(err, "error encoding raw json")
 		return newBytes
 	}
 	return bytes
@@ -130,12 +129,12 @@ func UpdateRecipeName(bytes []byte, t *testing.T) []byte {
 	t.WithFields(testing.Fields{
 		"recipe_name": rcpName,
 	}).MustTrue(exist, "there's no recipe id with specific recipe name")
-	t.MustNil(err, "there's an issue while getting recipe id from name")
+	t.MustNil(err, "error getting recipe id from name")
 	raw["RecipeID"] = rcpID
 	newBytes, err := json.Marshal(raw)
 	t.WithFields(testing.Fields{
 		"updated_recipe_id_interface": raw,
-	}).MustNil(err, "something went wrong encoding raw json")
+	}).MustNil(err, "error encoding raw json")
 	return newBytes
 }
 
@@ -149,12 +148,12 @@ func UpdateTradeExtraInfoToID(bytes []byte, t *testing.T) []byte {
 	t.WithFields(testing.Fields{
 		"trade_info": trdInfo,
 	}).MustTrue(exist, "there's not trade id with specific info")
-	t.MustNil(err, "there's an issue while getting trade id from info")
+	t.MustNil(err, "error getting trade id from info")
 	raw["TradeID"] = trdID
 	newBytes, err := json.Marshal(raw)
 	t.WithFields(testing.Fields{
 		"updated_trade_id_interface": raw,
-	}).MustNil(err, "something went wrong encoding raw json")
+	}).MustNil(err, "error encoding raw json")
 	return newBytes
 }
 
@@ -165,23 +164,20 @@ func UpdateExecID(bytes []byte, t *testing.T) []byte {
 	var execRefReader struct {
 		ExecRef string
 	}
-	if err := json.Unmarshal(bytes, &execRefReader); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &execRefReader)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling into exec ref")
 
 	var ok bool
 	raw["ExecID"], ok = execIDs[execRefReader.ExecRef]
-	if !ok {
-		t.WithFields(testing.Fields{
-			"execRef": execRefReader.ExecRef,
-		}).Fatal("execID not available")
-	}
+	t.WithFields(testing.Fields{
+		"execRef": execRefReader.ExecRef,
+	}).MustTrue(ok, "execID not available")
 	newBytes, err := json.Marshal(raw)
 	t.WithFields(testing.Fields{
 		"updated_exec_id_interface": raw,
-	}).MustNil(err, "something went wrong encoding raw json")
+	}).MustNil(err, "error encoding raw json")
 	return newBytes
 }
 
@@ -202,12 +198,12 @@ func UpdateItemIDFromName(bytes []byte, includeLockedByRcp bool, t *testing.T) [
 	t.WithFields(testing.Fields{
 		"item_name":      itemName,
 		"include_locked": includeLockedByRcp,
-	}).MustNil(err, "there's an issue while getting item id from name")
+	}).MustNil(err, "error getting item id from name")
 	raw["ItemID"] = itemID
 	newBytes, err := json.Marshal(raw)
 	t.WithFields(testing.Fields{
 		"updated_item_id_interface": raw,
-	}).MustNil(err, "something went wrong encoding raw json")
+	}).MustNil(err, "error encoding raw json")
 	return newBytes
 }
 
@@ -216,11 +212,10 @@ func GetItemIDsFromNames(bytes []byte, includeLockedByRcp bool, t *testing.T) []
 	var itemNamesResp struct {
 		ItemNames []string
 	}
-	if err := json.Unmarshal(bytes, &itemNamesResp); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &itemNamesResp)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling into item names")
 	ItemIDs := []string{}
 
 	for _, itemName := range itemNamesResp.ItemNames {
@@ -234,7 +229,7 @@ func GetItemIDsFromNames(bytes []byte, includeLockedByRcp bool, t *testing.T) []
 		t.WithFields(testing.Fields{
 			"name":           itemName,
 			"include_locked": includeLockedByRcp,
-		}).MustNil(err, "something went wrong getting item id from name")
+		}).MustNil(err, "error getting item id from name")
 		ItemIDs = append(ItemIDs, itemID)
 	}
 	return ItemIDs
@@ -245,11 +240,10 @@ func GetItemInputsFromBytes(bytes []byte, t *testing.T) types.ItemInputList {
 	var itemInputRefsReader struct {
 		ItemInputRefs []string
 	}
-	if err := json.Unmarshal(bytes, &itemInputRefsReader); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &itemInputRefsReader)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling into item input refs")
 
 	var itemInputs types.ItemInputList
 
@@ -259,8 +253,8 @@ func GetItemInputsFromBytes(bytes []byte, t *testing.T) types.ItemInputList {
 		err := inttest.GetAminoCdc().UnmarshalJSON(iiBytes, &ii)
 		if err != nil {
 			t.WithFields(testing.Fields{
-				"error": err,
-			}).Fatal("error unmarshaling")
+				"item_input_bytes": string(iiBytes),
+			}).MustNil(err, "error unmarshaling item inputs")
 		}
 		itemInputs = append(itemInputs, ii)
 	}
@@ -272,11 +266,10 @@ func GetTradeItemInputsFromBytes(bytes []byte, t *testing.T) types.TradeItemInpu
 	var itemInputRefsReader struct {
 		ItemInputRefs []string
 	}
-	if err := json.Unmarshal(bytes, &itemInputRefsReader); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &itemInputRefsReader)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling into trade item input refs")
 
 	var itemInputs types.TradeItemInputList
 
@@ -284,11 +277,9 @@ func GetTradeItemInputsFromBytes(bytes []byte, t *testing.T) types.TradeItemInpu
 		var tii types.TradeItemInput
 		tiiBytes := ReadFile(tiiRef, t)
 		err := inttest.GetAminoCdc().UnmarshalJSON(tiiBytes, &tii)
-		if err != nil {
-			t.WithFields(testing.Fields{
-				"error": err,
-			}).Fatal("error unmarshaling")
-		}
+		t.WithFields(testing.Fields{
+			"trade_item_input_bytes": string(tiiBytes),
+		}).MustNil(err, "error unmarshaling trading item inputs")
 		itemInputs = append(itemInputs, tii)
 	}
 	return itemInputs
@@ -299,11 +290,10 @@ func GetItemOutputsFromBytes(bytes []byte, sender string, t *testing.T) types.It
 	var itemOutputNamesReader struct {
 		ItemOutputNames []string
 	}
-	if err := json.Unmarshal(bytes, &itemOutputNamesReader); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &itemOutputNamesReader)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling into item output names")
 
 	var itemOutputs types.ItemList
 
@@ -313,11 +303,11 @@ func GetItemOutputsFromBytes(bytes []byte, sender string, t *testing.T) types.It
 		t.MustTrue(ok, "item id with specific name does not exist")
 		t.WithFields(testing.Fields{
 			"item_name": iN,
-		}).MustNil(err, "there's an issue while getting item id from name")
+		}).MustNil(err, "error getting item id from name")
 		io, err = inttest.GetItemByGUID(iID)
 		t.WithFields(testing.Fields{
 			"item_id": iID,
-		}).MustNil(err, "there's an issue while getting item from id")
+		}).MustNil(err, "error getting item from id")
 		itemOutputs = append(itemOutputs, io)
 	}
 	return itemOutputs
@@ -338,11 +328,10 @@ func GetEntriesFromBytes(bytes []byte, t *testing.T) types.EntriesList {
 		}
 	}
 
-	if err := json.Unmarshal(bytes, &entriesReader); err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling")
-	}
+	err := json.Unmarshal(bytes, &entriesReader)
+	t.WithFields(testing.Fields{
+		"bytes": string(bytes),
+	}).MustNil(err, "error unmarshaling into entries reader")
 
 	var wpl types.EntriesList
 	for _, co := range entriesReader.Entries.CoinOutputs {
@@ -354,12 +343,9 @@ func GetEntriesFromBytes(bytes []byte, t *testing.T) types.EntriesList {
 		if len(io.Ref) > 0 {
 			ioBytes := ReadFile(io.Ref, t)
 			err := json.Unmarshal(ioBytes, &pio)
-			if err != nil {
-				t.WithFields(testing.Fields{
-					"item_output_bytes": string(ioBytes),
-					"error":             err,
-				}).Fatal("error unmarshaling")
-			}
+			t.WithFields(testing.Fields{
+				"item_output_bytes": string(ioBytes),
+			}).MustNil(err, "error unmarshaling into item outputs")
 		}
 		if io.ModifyItem.ItemInputRef == nil {
 			pio.ModifyItem.ItemInputRef = -1
@@ -404,12 +390,9 @@ func GetModifyParamsFromRef(ref string, t *testing.T) types.ItemModifyParams {
 	}
 	modBytes := ReadFile(ref, t)
 	err := json.Unmarshal(modBytes, &iup)
-	if err != nil {
-		t.WithFields(testing.Fields{
-			"modify_param_bytes": string(modBytes),
-			"error":              err,
-		}).Fatal("error unmarshaling")
-	}
+	t.WithFields(testing.Fields{
+		"modify_param_bytes": string(modBytes),
+	}).MustNil(err, "error unmarshaling")
 
 	return iup
 }

--- a/cmd/test/basic_utils.go
+++ b/cmd/test/basic_utils.go
@@ -125,13 +125,10 @@ func RunPylonsCli(args []string, stdinInput string) ([]byte, string, error) {
 func GetAccountAddr(account string, t *testing.T) string {
 	addrBytes, logstr, err := RunPylonsCli([]string{"keys", "show", account, "-a"}, "")
 	addr := strings.Trim(string(addrBytes), "\n ")
-	if t != nil && err != nil {
-		t.WithFields(testing.Fields{
-			"account": account,
-			"error":   err,
-			"log":     logstr,
-		}).Fatal("error getting account address")
-	}
+	t.WithFields(testing.Fields{
+		"account": account,
+		"log":     logstr,
+	}).MustNil(err, "error getting account address")
 	return addr
 }
 
@@ -139,18 +136,17 @@ func GetAccountAddr(account string, t *testing.T) string {
 func GetAccountInfoFromAddr(addr string, t *testing.T) auth.BaseAccount {
 	var accInfo auth.BaseAccount
 	accBytes, logstr, err := RunPylonsCli([]string{"query", "account", addr}, "")
-	if t != nil && err != nil {
-		t.WithFields(testing.Fields{
-			"address": addr,
-			"error":   err,
-			"log":     logstr,
-		}).Fatal("error getting account info")
+	t.WithFields(testing.Fields{
+		"address": addr,
+		"log":     logstr,
+	}).MustNil(err, "error getting account info")
+	if err != nil {
 		return accInfo
 	}
 	err = GetAminoCdc().UnmarshalJSON(accBytes, &accInfo)
 	t.WithFields(testing.Fields{
 		"acc_bytes": string(accBytes),
-	}).MustNil(err, "something went wrong decoding raw json")
+	}).MustNil(err, "error decoding raw json")
 	// t.WithFields(testing.Fields{
 	// 	"account_info": accInfo,
 	// }).Debug("debug log")

--- a/cmd/test/query_utils.go
+++ b/cmd/test/query_utils.go
@@ -91,11 +91,9 @@ func ListExecutionsViaCLI(account string, t *testing.T) ([]types.Execution, erro
 	}
 	var listExecutionsResp queriers.ExecResponse
 	err = GetAminoCdc().UnmarshalJSON(output, &listExecutionsResp)
-	if err != nil {
-		t.WithFields(testing.Fields{
-			"error": err,
-		}).Fatal("error unmarshaling list executions")
-	}
+	t.WithFields(testing.Fields{
+		"list_executions_output": string(output),
+	}).MustNil(err, "error unmarshaling list executions")
 	return listExecutionsResp.Executions, err
 }
 
@@ -144,6 +142,9 @@ func GetTxError(txhash string, t *testing.T) ([]byte, error) {
 		return []byte{}, err
 	}
 
+	// TODO this is not correct in some cases
+	// Errors can happen with internal error or something other
+	// We need to check log is in JSON format or it's not json parsable to check if there's an issue
 	if strings.Contains(tx.RawLog, "invalid request") {
 		return []byte(tx.RawLog), nil
 	}

--- a/cmd/test/query_utils.go
+++ b/cmd/test/query_utils.go
@@ -2,8 +2,8 @@ package inttest
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
-	"strings"
 
 	testing "github.com/Pylons-tech/pylons_sdk/cmd/fixtures_test/evtesting"
 
@@ -130,6 +130,12 @@ func WaitAndGetTxError(txhash string, maxWaitBlock int64, t *testing.T) ([]byte,
 	return txErrorResBytes, nil
 }
 
+// IsJSON checks if bytes is in json
+func IsJSON(str string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(str), &js) == nil
+}
+
 // GetTxError is a function to get transaction error from txhash
 func GetTxError(txhash string, t *testing.T) ([]byte, error) {
 	output, _, err := RunPylonsCli([]string{"query", "tx", txhash}, "")
@@ -142,10 +148,7 @@ func GetTxError(txhash string, t *testing.T) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	// TODO this is not correct in some cases
-	// Errors can happen with internal error or something other
-	// We need to check log is in JSON format or it's not json parsable to check if there's an issue
-	if strings.Contains(tx.RawLog, "invalid request") {
+	if !IsJSON(tx.RawLog) {
 		return []byte(tx.RawLog), nil
 	}
 	return []byte{}, nil

--- a/cmd/test/tx_utils.go
+++ b/cmd/test/tx_utils.go
@@ -80,20 +80,20 @@ func broadcastTxFile(signedTxFile string, maxRetry int, t *testing.T) (string, e
 		// }).Debug("debug log")
 
 		t.WithFields(testing.Fields{
-			"broadcast_args": txBroadcastArgs,
-			"output":         string(output),
-			"broadcast_log":  logstr,
-		}).MustNil(err, "there's an issue while running pylonscli broadcast command")
+			"broadcast_args":   txBroadcastArgs,
+			"broadcast_output": string(output),
+			"broadcast_log":    logstr,
+		}).MustNil(err, "error running pylonscli broadcast command")
 		txResponse := sdk.TxResponse{}
 
 		err = GetAminoCdc().UnmarshalJSON(output, &txResponse)
 		// This can happen when "pylonscli config output json" is not set or when real issue is available
+		t.WithFields(testing.Fields{
+			"broadcast_output":  string(output),
+			"possible_solution": "You can set cli config output as json to solve this issue",
+		}).MustNil(err, "error decoding transaction broadcast result")
+
 		if err != nil {
-			t.WithFields(testing.Fields{
-				"broadcast_output":  string(output),
-				"error":             err,
-				"possible_solution": "You can set cli config output as json to solve this issue",
-			}).Fatal("error decoding transaction broadcast result")
 			return txResponse.TxHash, err
 		}
 
@@ -122,7 +122,7 @@ func broadcastTxFile(signedTxFile string, maxRetry int, t *testing.T) (string, e
 	err := json.Unmarshal(signedTx, &postBodyJSON)
 	t.WithFields(testing.Fields{
 		"signed_tx": string(signedTx),
-	}).MustNil(err, "something went wrong decoding raw json")
+	}).MustNil(err, "error decoding raw json")
 
 	postBodyJSON["tx"] = postBodyJSON["value"]
 	postBodyJSON["value"] = nil
@@ -146,7 +146,7 @@ func broadcastTxFile(signedTxFile string, maxRetry int, t *testing.T) (string, e
 	var result map[string]string
 
 	err = json.NewDecoder(resp.Body).Decode(&result)
-	t.MustNil(err, "something went wrong decoding raw json")
+	t.MustNil(err, "error decoding raw json")
 	defer resp.Body.Close()
 	t.WithFields(testing.Fields{
 		"get_pylons_api_response": result,
@@ -167,9 +167,9 @@ func TestTxWithMsg(t *testing.T, msgValue sdk.Msg, signer string) string {
 	signedTxFile := filepath.Join(tmpDir, "signed_tx.json")
 
 	txModel, err := GenTxWithMsg([]sdk.Msg{msgValue})
-	t.MustNil(err, "there's an issue while while building transaction model from messages")
+	t.MustNil(err, "error while building transaction model from messages")
 	output, err := GetAminoCdc().MarshalJSON(txModel)
-	t.MustNil(err, "something went wrong encoding transaction model")
+	t.MustNil(err, "error encoding transaction model")
 
 	err = ioutil.WriteFile(rawTxFile, output, 0644)
 	if err != nil {

--- a/cmd/test/tx_utils.go
+++ b/cmd/test/tx_utils.go
@@ -42,7 +42,7 @@ func GenTxWithMsg(messages []sdk.Msg) (auth.StdTx, error) {
 	var err error
 	for i, msg := range messages {
 		if err = msg.ValidateBasic(); err != nil {
-			return auth.StdTx{}, fmt.Errorf("%dth msg does not pass basic validation for %+v", i, err)
+			return auth.StdTx{}, fmt.Errorf("%dth msg does not pass basic validation for %s", i, err.Error())
 		}
 	}
 	cdc := GetAminoCdc()

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.6.3
-	github.com/stretchr/testify v1.5.1
 	github.com/tendermint/go-amino v0.15.1
 	github.com/tendermint/tendermint v0.33.3
 	github.com/tendermint/tm-db v0.5.1 // indirect


### PR DESCRIPTION
- Updated MustNil, MustTrue checker to log full trace stack
- Updated Fatal loggers to use MustNil and MustTrue to log full trace
- Added MustContain function into testing package as it’s used much
- Unique logging text format
- Log transaction error log when transaction result unmarshal has failure